### PR TITLE
Fix click target when cursor is outside a word

### DIFF
--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -600,6 +600,8 @@ qint64 QHexView::pixelToWord(int x, int y) const {
 
 	switch(highlighting_) {
 	case Highlighting_Data:
+        // Make pixels outside the word correspond to the nearest word, not to the right-hand one
+        x -= font_width_/2;
 		// the right edge of a box is kinda quirky, so we pretend there is one
 		// extra character there
 		x = qBound(vertline1(), x, static_cast<int>(vertline2() + font_width_));


### PR DESCRIPTION
This would fix https://github.com/eteran/edb-debugger/issues/370.