### PR TITLE
Always select at least one word on click or drag

### DIFF
--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -724,7 +724,8 @@ void QHexView::mousePressEvent(QMouseEvent *event) {
 		}
 
 		if(offset < dataSize()) {
-			selection_start_ = selection_end_ = byte_offset;
+			selection_start_ = byte_offset;
+			selection_end_ = selection_start_ + word_width_;
 		} else {
 			selection_start_ = selection_end_ = -1;
 		}
@@ -747,7 +748,7 @@ void QHexView::mouseMoveEvent(QMouseEvent *event) {
 
 		if(selection_start_ != -1) {
 			if(offset == -1) {
-				selection_end_ = (row_width_ - selection_start_) + selection_start_;
+				selection_end_ = row_width_;
 			} else {
 
 				qint64 byte_offset = (offset * word_width_);
@@ -759,6 +760,9 @@ void QHexView::mouseMoveEvent(QMouseEvent *event) {
 
 				}
 				selection_end_ = byte_offset;
+				if (selection_end_ == selection_start_) {
+					selection_end_ += word_width_;
+				}
 			}
 
 			if(selection_end_ < 0) {


### PR DESCRIPTION
Fixes eteran/edb-debugger#371

I used @10110111 's recommended patch which makes a single click select at least one word instead of selecting nothing. I also expanded it by making a click+drag also attempt to select at least one word.