### PR TITLE
UI Tweaks

### DIFF
--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -653,9 +653,11 @@ void QHexView::updateToolTip() {
 	auto sb = selectedBytes();
 	auto tooltip = QString("<p style='white-space:pre'>"); //prevent word wrap
 #if 0
+	// Plain formatting with 0x prefix
 	tooltip += QString("<b>Addr:</b> 0x%1 - 0x%2").arg(selectedBytesAddress(), 0, 16)
 												  .arg(selectedBytesAddress() + sb.size(), 0, 16);
 #else
+	// Segment:Offset style formatting is easier to read
 	const address_t start = selectedBytesAddress();
 	const address_t end = selectedBytesAddress() + sb.size();
 	tooltip += "<b>Addr: </b>" + formatAddress(start) + " - " + formatAddress(end);

--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -701,6 +701,8 @@ void QHexView::updateToolTip() {
 		% QString("<b>Range: </b>") % formatAddress(start) % " - " % formatAddress(end)
 		% QString("<br><b>UInt32:</b> ") % QString::number(qFromLittleEndian<quint32>(sb.data()))
 		% QString("<br><b>Int32:</b> ") % QString::number(qFromLittleEndian<qint32>(sb.data()))
+		% QString("<br><b>UInt64:</b> ") % QString::number(qFromLittleEndian<quint64>(sb.data()))
+		% QString("<br><b>Int64</b> ") % QString::number(qFromLittleEndian<qint64>(sb.data()))
 		% QString("</p>");
 
 	setToolTip(tooltip);

--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -637,8 +637,14 @@ void QHexView::updateToolTip() {
 
 	auto sb = selectedBytes();
 	auto tooltip = QString("<p style='white-space:pre'>"); //prevent word wrap
+#if 0
 	tooltip += QString("<b>Addr:</b> 0x%1 - 0x%2").arg(selectedBytesAddress(), 0, 16)
-												.arg(selectedBytesAddress() + sb.size(), 0, 16);
+												  .arg(selectedBytesAddress() + sb.size(), 0, 16);
+#else
+	const address_t start = selectedBytesAddress();
+	const address_t end = selectedBytesAddress() + sb.size();
+	tooltip += "<b>Addr: </b>" + formatAddress(start) + " - " + formatAddress(end);
+#endif
 	tooltip += "<br><b>Hex:</b> 0x" + sb.toHex();
 	tooltip += "<br><b>UInt32:</b> " + QString::number(qFromLittleEndian<quint32>(sb.data()));
 	tooltip += "<br><b>Int32:</b> " + QString::number(qFromLittleEndian<qint32>(sb.data()));

--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -29,6 +29,7 @@ The license chosen is at the discretion of the user of this software.
 #include <QTextStream>
 #include <QtGlobal>
 #include <QtEndian>
+#include <QStringBuilder>
 
 #include <cctype>
 #include <climits>
@@ -692,14 +693,17 @@ void QHexView::updateToolTip() {
 	}
 
 	auto sb = selectedBytes();
-	auto tooltip = QString("<p style='white-space:pre'>"); //prevent word wrap
 	const address_t start = selectedBytesAddress();
 	const address_t end = selectedBytesAddress() + sb.size();
-	tooltip += "<b>Addr: </b>" + formatAddress(start) + " - " + formatAddress(end);
-	tooltip += "<br><b>Hex:</b> 0x" + sb.toHex();
-	tooltip += "<br><b>UInt32:</b> " + QString::number(qFromLittleEndian<quint32>(sb.data()));
-	tooltip += "<br><b>Int32:</b> " + QString::number(qFromLittleEndian<qint32>(sb.data()));
-	tooltip += "</p>";
+
+	QString tooltip = //noWordWrap % addr;
+		QString("<p style='white-space:pre'>")	//prevent word wrap
+		% QString("<b>Addr: </b>") % formatAddress(start) % " - " % formatAddress(end)
+		% QString("<br><b>Hex:</b> 0x") % sb.toHex()
+		% QString("<br><b>UInt32:</b> ") % QString::number(qFromLittleEndian<quint32>(sb.data()))
+		% QString("<br><b>Int32:</b> ") % QString::number(qFromLittleEndian<qint32>(sb.data()))
+		% QString("</p>");
+
 	setToolTip(tooltip);
 }
 

--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -737,8 +737,12 @@ void QHexView::mousePressEvent(QMouseEvent *event) {
 		}
 
 		if(offset < dataSize()) {
-			selection_start_ = byte_offset;
-			selection_end_ = selection_start_ + word_width_;
+			if (hasSelectedText() && (event->modifiers() & Qt::ShiftModifier)) {
+				selection_end_ = byte_offset;
+			} else {
+				selection_start_ = byte_offset;
+				selection_end_ = selection_start_ + word_width_;
+			}
 		} else {
 			selection_start_ = selection_end_ = -1;
 		}

--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -395,6 +395,47 @@ void QHexView::keyPressEvent(QKeyEvent *event) {
 		if(offset > 0) {
 			scrollTo(offset - 1);
 		}
+	} else if(event->modifiers() & Qt::ShiftModifier && hasSelectedText()) {
+		// Attempting to match the highlighting behavior of common text
+		// editors where highlighting to the left or up will keep the
+		// first character (byte in our case) highlighted while also
+		// extending back or up.
+		auto dir = event->key();
+		switch(dir) {
+		case Qt::Key_Right:
+			if (selection_start_ == selection_end_) {
+				selection_start_ -= word_width_;
+			}
+			if(selection_end_ / word_width_ < dataSize()) {
+				selection_end_ += word_width_;
+			}
+			break;
+		case Qt::Key_Left:
+			if ((selection_end_ - word_width_) == selection_start_) {
+				selection_start_ += word_width_;
+				selection_end_ -= word_width_;
+			}
+			if (selection_end_ / word_width_ > 0) {
+				selection_end_ -= word_width_;
+			}
+			break;
+		case Qt::Key_Down:
+			selection_end_ += row_width_;
+			selection_end_ = std::min(selection_end_, dataSize() * word_width_);
+			break;
+		case Qt::Key_Up:
+			if ((selection_end_ - word_width_) == selection_start_) {
+				selection_start_ += word_width_;
+			}
+			selection_end_ -= row_width_;
+			if (selection_end_ == 0) {
+				 selection_end_ = 0;
+			}
+			break;
+		default:
+			break;
+		}
+		viewport()->update();
 	} else {
 		QAbstractScrollArea::keyPressEvent(event);
 	}

--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -699,7 +699,6 @@ void QHexView::updateToolTip() {
 	QString tooltip = //noWordWrap % addr;
 		QString("<p style='white-space:pre'>")	//prevent word wrap
 		% QString("<b>Addr: </b>") % formatAddress(start) % " - " % formatAddress(end)
-		% QString("<br><b>Hex:</b> 0x") % sb.toHex()
 		% QString("<br><b>UInt32:</b> ") % QString::number(qFromLittleEndian<quint32>(sb.data()))
 		% QString("<br><b>Int32:</b> ") % QString::number(qFromLittleEndian<qint32>(sb.data()))
 		% QString("</p>");

--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -28,6 +28,7 @@ The license chosen is at the discretion of the user of this software.
 #include <QSignalMapper>
 #include <QTextStream>
 #include <QtGlobal>
+#include <QtEndian>
 
 #include <cctype>
 #include <climits>
@@ -627,6 +628,25 @@ int64_t QHexView::pixelToWord(int x, int y) const {
 }
 
 //------------------------------------------------------------------------------
+// Name: setToolTip
+//------------------------------------------------------------------------------
+void QHexView::updateToolTip() {
+	if(selectedBytesSize() <= 0) {
+		return;
+	}
+
+	auto sb = selectedBytes();
+	auto tooltip = QString("<p style='white-space:pre'>"); //prevent word wrap
+	tooltip += QString("<b>Addr:</b> 0x%1 - 0x%2").arg(selectedBytesAddress(), 0, 16)
+												.arg(selectedBytesAddress() + sb.size(), 0, 16);
+	tooltip += "<br><b>Hex:</b> 0x" + sb.toHex();
+	tooltip += "<br><b>UInt32:</b> " + QString::number(qFromLittleEndian<quint32>(sb.data()));
+	tooltip += "<br><b>Int32:</b> " + QString::number(qFromLittleEndian<qint32>(sb.data()));
+	tooltip += "</p>";
+	setToolTip(tooltip);
+}
+
+//------------------------------------------------------------------------------
 // Name: mouseDoubleClickEvent
 //------------------------------------------------------------------------------
 void QHexView::mouseDoubleClickEvent(QMouseEvent *event) {
@@ -666,6 +686,8 @@ void QHexView::mouseDoubleClickEvent(QMouseEvent *event) {
 			viewport()->update();
 		}
 	}
+
+	updateToolTip();
 }
 
 //------------------------------------------------------------------------------
@@ -702,6 +724,8 @@ void QHexView::mousePressEvent(QMouseEvent *event) {
 	if (event->button() == Qt::RightButton) {
 
 	}
+
+	updateToolTip();
 }
 
 //------------------------------------------------------------------------------
@@ -743,6 +767,7 @@ void QHexView::mouseMoveEvent(QMouseEvent *event) {
 
 		}
 		viewport()->update();
+		updateToolTip();
 	}
 }
 

--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -643,7 +643,7 @@ int64_t QHexView::pixelToWord(int x, int y) const {
 }
 
 //------------------------------------------------------------------------------
-// Name: setToolTip
+// Name: updateToolTip
 //------------------------------------------------------------------------------
 void QHexView::updateToolTip() {
 	if(selectedBytesSize() <= 0) {

--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -696,7 +696,7 @@ void QHexView::updateToolTip() {
 	const address_t start = selectedBytesAddress();
 	const address_t end = selectedBytesAddress() + sb.size();
 
-	QString tooltip = //noWordWrap % addr;
+	QString tooltip =
 		QString("<p style='white-space:pre'>")	//prevent word wrap
 		% QString("<b>Range: </b>") % formatAddress(start) % " - " % formatAddress(end)
 		% QString("<br><b>UInt32:</b> ") % QString::number(qFromLittleEndian<quint32>(sb.data()))

--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -698,7 +698,7 @@ void QHexView::updateToolTip() {
 
 	QString tooltip = //noWordWrap % addr;
 		QString("<p style='white-space:pre'>")	//prevent word wrap
-		% QString("<b>Addr: </b>") % formatAddress(start) % " - " % formatAddress(end)
+		% QString("<b>Range: </b>") % formatAddress(start) % " - " % formatAddress(end)
 		% QString("<br><b>UInt32:</b> ") % QString::number(qFromLittleEndian<quint32>(sb.data()))
 		% QString("<br><b>Int32:</b> ") % QString::number(qFromLittleEndian<qint32>(sb.data()))
 		% QString("</p>");

--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -226,7 +226,7 @@ QMenu *QHexView::createStandardContextMenu() {
 
 	menu->addSeparator();
 	menu->addAction(tr("&Copy Selection To Clipboard"), this, SLOT(mnuCopy()));
-
+	menu->addAction(tr("&Copy Address To Clipboard"), this, SLOT(mnuAddrCopy()));
 	return menu;
 }
 
@@ -311,6 +311,21 @@ void QHexView::mnuCopy() {
 			offset += chars_per_row;
 		}
 
+		QApplication::clipboard()->setText(s);
+
+		// TODO(eteran): do we want to trample the X11-selection too?
+		QApplication::clipboard()->setText(s, QClipboard::Selection);
+	}
+}
+
+//------------------------------------------------------------------------------
+// Name: mnuAddrCopy
+// Desc: Copy the starting address of the selected bytes
+//------------------------------------------------------------------------------
+void QHexView::mnuAddrCopy() {
+	if(hasSelectedText()) {
+
+		auto s = QString("0x%1").arg(selectedBytesAddress(), 0, 16);
 		QApplication::clipboard()->setText(s);
 
 		// TODO(eteran): do we want to trample the X11-selection too?

--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -693,16 +693,9 @@ void QHexView::updateToolTip() {
 
 	auto sb = selectedBytes();
 	auto tooltip = QString("<p style='white-space:pre'>"); //prevent word wrap
-#if 0
-	// Plain formatting with 0x prefix
-	tooltip += QString("<b>Addr:</b> 0x%1 - 0x%2").arg(selectedBytesAddress(), 0, 16)
-												  .arg(selectedBytesAddress() + sb.size(), 0, 16);
-#else
-	// Segment:Offset style formatting is easier to read
 	const address_t start = selectedBytesAddress();
 	const address_t end = selectedBytesAddress() + sb.size();
 	tooltip += "<b>Addr: </b>" + formatAddress(start) + " - " + formatAddress(end);
-#endif
 	tooltip += "<br><b>Hex:</b> 0x" + sb.toHex();
 	tooltip += "<br><b>UInt32:</b> " + QString::number(qFromLittleEndian<quint32>(sb.data()));
 	tooltip += "<br><b>Int32:</b> " + QString::number(qFromLittleEndian<qint32>(sb.data()));

--- a/qhexview.h
+++ b/qhexview.h
@@ -131,6 +131,7 @@ public Q_SLOTS:
 	void deselect();
 	void mnuSetFont();
 	void mnuCopy();
+	void mnuAddrCopy();
 
 private:
 	QString formatAddress(address_t address);

--- a/qhexview.h
+++ b/qhexview.h
@@ -157,6 +157,7 @@ private:
 	void drawHexDumpToBuffer(QTextStream &stream, uint64_t offset, uint64_t size, const QByteArray &row_data) const;
 	void ensureVisible(int64_t index);
 	void updateScrollbars();
+	void updateToolTip();
 
 private:
 	std::unique_ptr<CommentServerBase> commentServer_;


### PR DESCRIPTION
This PR implements two feature requests in edb-debugger: [value conversions](https://github.com/eteran/edb-debugger/issues/694) and [displaying the address of selected bytes](https://github.com/eteran/edb-debugger/issues/681).

I also added in arrow-key based highlighting as found in common editors: with some text highlighted, you can hold shift and use the arrow keys to highlight left, right, up, or down.

I don't know much about Qt so there might have been better ways to do some of this; feedback or edits are definitely welcome. I've only tested on Linux.